### PR TITLE
glide now uses bootstrap-dist instead of bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p ./src/github.com/Masterminds
 WORKDIR $GOPATH/src/github.com/Masterminds
 RUN git clone https://github.com/Masterminds/glide
 WORKDIR glide
-RUN make bootstrap
+RUN make bootstrap-dist
 RUN make install
 RUN mkdir -p $GOPATH/src/github.com/coreos
 


### PR DESCRIPTION
https://github.com/Masterminds/glide/blob/master/Makefile#L27 I'm not sure if theres a better way to do this.